### PR TITLE
change_pw를 put에서 patch로 바꾸고, send_pw에서 def get()의 인자로 request, *args가…

### DIFF
--- a/django_app/member/views/password_change.py
+++ b/django_app/member/views/password_change.py
@@ -15,7 +15,7 @@ __all__ = ('PasswordSendView', 'PasswordChangeView', )
 
 class PasswordSendView(GenericAPIView):
 
-    def get(self, **kwargs):
+    def get(self, request, *args, **kwargs):
         if kwargs.get('email',''):
             email = kwargs['email']
             code = binascii.hexlify(os.urandom(12))[:12]
@@ -29,7 +29,7 @@ class PasswordSendView(GenericAPIView):
                     'yunsoo3042@gmail.com',
                     [email],
                 )
-                return Response({"successs": "성공했습니다"},status=status.HTTP_200_OK)
+                return Response({"success": "성공했습니다"},status=status.HTTP_200_OK)
             return Response({"detail": "입력하신 이메일은 존재하지 않는 유저입니다"}, status=status.HTTP_404_NOT_FOUND)
         return Response({"detail": "get parameter로 email인자가 없습니다"}, status=status.HTTP_404_NOT_FOUND)
 
@@ -39,11 +39,17 @@ class PasswordChangeView(UpdateAPIView):
     serializer_class = PwChangeSerializer
     queryset = User.objects.all()
 
+    def put(self, request, *args, **kwargs):
+        return Response({"detail": "put method는 허용되지 않습니다"}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
     def patch(self, request, *args, **kwargs):
-        return Response({"detail": "patch method는 허용되지 않습니다"}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        print(request.data)
+        return self.update(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
         instance = self.request.user
+        request.data._mutable = True
+        request.data['email'] = request.user.email
         serializer = self.get_serializer(instance, data=request.data)
         serializer.is_valid(raise_exception=True)
         self.do_update(request)


### PR DESCRIPTION
change password 뷰에서 원래 PUT으로 입력을 받던 것을 Patch로 바꿔줌으로써, 클라이언트에서 email을 넣지 않고도(사실 클라이언트에서 이메일 주소를 보내주기는 어려울 것으로 생각해서) password1과 password2를 입력하면 request.user에서 찾을수 있도록 처리. 
send_password뷰에서 def get(self, **kwargs)로 작성했는데, *args가 없어서 get 함수 내부에서 오류가 생기어 
def get(self, request, *args, **kwargs)로 수정. 